### PR TITLE
Add `_filename` to locals

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 import jade from 'jade'
 import Joi from 'joi'
+import path from 'path'
 
 module.exports = function (source) {
   this.cacheable && this.cacheable(true)
@@ -16,7 +17,7 @@ module.exports = function (source) {
     compiler: Joi.func(),
     parser: Joi.func(),
     globals: Joi.array().single(),
-    locals: Joi.object()
+    locals: Joi.object().default({})
   })
 
   // validate options
@@ -31,6 +32,7 @@ module.exports = function (source) {
   tpl.dependencies.map(this.addDependency.bind(this))
 
   // render template
+  opts.locals._filename = path.basename(this.resourcePath, '.jade')
   const rendered = tpl(opts.locals)
 
   // stringify before returning so it's valid js for webpack

--- a/test/fixtures/filename/app.js
+++ b/test/fixtures/filename/app.js
@@ -1,0 +1,1 @@
+require('./index.jade')

--- a/test/fixtures/filename/index.jade
+++ b/test/fixtures/filename/index.jade
@@ -1,0 +1,1 @@
+= _filename

--- a/test/index.js
+++ b/test/index.js
@@ -76,3 +76,19 @@ test.cb('throws if options are invalid', (t) => {
     }
   })
 })
+
+test.cb('passes the filename through the build', (t) => {
+  const p = path.join(fixturesPath, 'filename')
+  webpack({
+    context: p,
+    entry: path.join(p, 'app.js'),
+    output: { path: p },
+    resolveLoader: { root: path.resolve('..') },
+    module: { loaders: [{ test: /\.jade$/, loader: 'lib' }] }
+  }, (err, stats) => {
+    if (err) { t.end(err) }
+    const src = fs.readFileSync(path.join(p, 'bundle.js'), 'utf8')
+    t.ok(src.match('index'))
+    rimraf(path.join(p, 'bundle.js'), t.end)
+  })
+})


### PR DESCRIPTION
In the future we probably want to add relative path to where the base is. For example `views/blog/index.jade` should return `blog/index`. 

Additionally in roots-mini-base we should transform `blog/index` into `blog_index`
